### PR TITLE
ci: publish releases to the Homebrew tap

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -286,3 +286,17 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.FULL_IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+
+  tap:
+    name: Update Homebrew Tap
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    needs:
+      - build
+    steps:
+      - name: Update Homebrew Tap
+        uses: SierraSoftworks/actions-tap@v1
+        with:
+          app-id: ${{ secrets.TAP_APP_ID }}
+          private-key: ${{ secrets.TAP_APP_PRIVATE_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add a release-only fan-in job that runs after the build matrix (needs: build) and calls SierraSoftworks/actions-tap to update the imgsort formula in the Homebrew tap. Guarded with if: github.event_name == 'release' so it only runs on published releases, not on push or pull_request events.