### PR TITLE
Fix Docker build by using correct imgsort binary name

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -218,7 +218,7 @@ jobs:
           context: .
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.FULL_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true,annotation-index.org.opencontainers.image.description=Backup your GitHub repositories and releases automatically
+          outputs: type=image,name=${{ env.FULL_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true,annotation-index.org.opencontainers.image.description=Automatically sort and deduplicate your photographs based on their EXIF metadata
 
       - name: Export digest
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-# NOTE: This Dockerfile depends on you building the github-backup binary first.
+# NOTE: This Dockerfile depends on you building the imgsort binary first.
 # It will then package that binary into the image, and use that as the entrypoint.
 # This means that running `docker build` is not a repeatable way to build the same
 # image, but the benefit is much faster cross-platform builds; a net win.
 FROM debian:bookworm-slim
 
-LABEL org.opencontainers.image.source=https://github.com/SierraSoftworks/github-backup
-LABEL org.opencontainers.image.description="Backup your GitHub repositories and releases automatically"
+LABEL org.opencontainers.image.source=https://github.com/SierraSoftworks/imgsort
+LABEL org.opencontainers.image.description="Automatically sort and deduplicate your photographs based on their EXIF metadata"
 LABEL org.opencontainers.image.licenses=MIT
 
 RUN apt-get update && apt-get install -y \
   openssl
 
-ADD ./github-backup /usr/local/bin/github-backup
+ADD ./imgsort /usr/local/bin/imgsort
 
-ENTRYPOINT ["/usr/local/bin/github-backup"]
+ENTRYPOINT ["/usr/local/bin/imgsort"]


### PR DESCRIPTION
## Problem

The Docker build was failing because the `Dockerfile` still referenced the `github-backup` binary — leftover from when it was copied out of the [github-backup](https://github.com/SierraSoftworks/github-backup) project.

The `docker-build` job in `.github/workflows/rust.yml` builds and uploads an artifact named `imgsort`, downloads it into the build context, and marks `./imgsort` executable. But the Dockerfile then tried to `ADD ./github-backup`, a file that doesn't exist in the context, so the build failed.

## Changes

- `Dockerfile`: package `./imgsort` instead of `./github-backup` and use it as the entrypoint.
- `Dockerfile`: fix the leftover `org.opencontainers.image.source` and `org.opencontainers.image.description` labels (and the header comment) to describe imgsort.
- `.github/workflows/rust.yml`: fix the matching `annotation-index.org.opencontainers.image.description` that also carried the old github-backup description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FfLsHiJZK8LDnUBtJy7WX6

---
_Generated by [Claude Code](https://claude.ai/code/session_01FfLsHiJZK8LDnUBtJy7WX6)_