### PR TITLE
docs: document Homebrew tap installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 This tool makes automated image organization workflows simple and straightforward,
 allowing you to manage large image libraries with minimal effort.
 
+## Installation
+Install with [Homebrew](https://brew.sh):
+```sh
+brew install sierrasoftworks/tap/imgsort
+```
+
 ## Features
 - **Automatic Organization**: Automatically sort your images into folders based on their EXIF metadata.
 - **Deduplication**: Automatically detect and remove duplicate images from your library based on the exact binary content of the image file.


### PR DESCRIPTION
Adds a concise Homebrew installation section to the README, pointing users at the Sierra Softworks tap:

    brew install sierrasoftworks/tap/imgsort

Part of the Homebrew tap rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
